### PR TITLE
Handle Gemini API errors

### DIFF
--- a/api/quote.js
+++ b/api/quote.js
@@ -11,22 +11,45 @@ export default async function handler(req, res) {
   }
 
   try {
-        const modelName = "gemini-2.5-pro"; // or "gemini-2.5-flash"
-        const result = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${GEMINI_API_KEY}`, {
+    const modelName = "gemini-2.5-pro"; // or "gemini-2.5-flash"
+    const result = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${GEMINI_API_KEY}`,
+      {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })
-        });
+        body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }),
+      },
+    );
 
-    const data = await result.json();
-    const reply = data?.candidates?.[0]?.content?.parts?.[0]?.text || "No response from Gemini.";
+    let data;
+    try {
+      data = await result.json();
+    } catch {
+      data = null;
+    }
 
     res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader("Access-Control-Allow-Methods", "GET, POST");
     res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
+    if (!result.ok) {
+      console.error("Gemini API error:", result.status, data);
+      const errorMessage = data?.error?.message || "Gemini API request failed.";
+      return res
+        .status(result.status)
+        .json({ error: errorMessage, status: result.status });
+    }
+
+    const reply =
+      data?.candidates?.[0]?.content?.parts?.[0]?.text ||
+      "No response from Gemini.";
+
     res.status(200).json({ reply });
   } catch (err) {
-    res.status(500).json({ error: "Gemini API request failed." });
+    console.error("Gemini API fetch error:", err);
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    res.status(500).json({ error: err.message || "Gemini API request failed." });
   }
 }


### PR DESCRIPTION
## Summary
- improve Gemini API error handling in `api/quote.js`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685842e299b0832e993609fdadd0001c