### PR TITLE
Update gemini model default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This project exposes a simple API endpoint for querying the Gemini API.
 
-The request is sent using the **gemini-pro** model (`api/quote.js`), which is the stable text model offered by the Gemini API.
+The request is sent using the **gemini-1.5-pro** model by default (`api/quote.js`).
+You can override this by setting a `GEMINI_MODEL` environment variable.
 
 To run the API you need to provide a `GEMINI_API_KEY` environment variable.
 

--- a/api/quote.js
+++ b/api/quote.js
@@ -11,7 +11,7 @@ export default async function handler(req, res) {
   }
 
   try {
-    const modelName = "gemini-pro"; // or "gemini-1.5-flash-latest"
+    const modelName = process.env.GEMINI_MODEL || "gemini-1.5-pro";
     const result = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${GEMINI_API_KEY}`,
       {


### PR DESCRIPTION
## Summary
- use gemini-1.5-pro as the default model
- allow overriding the model via `GEMINI_MODEL`
- document the new model choice in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68586d9e347c832eb35e64f9955db563