### PR TITLE
Update README for new model config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project exposes a simple API endpoint for querying the Gemini API.
 
 The request is sent using the **gemini-1.5-pro** model by default (`api/quote.js`).
-You can override this by setting a `GEMINI_MODEL` environment variable.
+You can override this default by setting the `GEMINI_MODEL` environment variable.
 
 To run the API you need to provide a `GEMINI_API_KEY` environment variable.
 
@@ -15,7 +15,13 @@ To run the API you need to provide a `GEMINI_API_KEY` environment variable.
    GEMINI_API_KEY=<your key here>
    ```
 
-2. Start your local server with your preferred tool (`vercel dev`, `node`, etc.). The API will read `GEMINI_API_KEY` from the `.env` file.
+2. *(Optional)* Specify a different model by adding `GEMINI_MODEL`:
+
+   ```bash
+   GEMINI_MODEL=gemini-1.5-flash
+   ```
+
+3. Start your local server with your preferred tool (`vercel dev`, `node`, etc.). The API will read `GEMINI_API_KEY` and `GEMINI_MODEL` from the `.env` file.
 
 ## Deploying to Vercel
 


### PR DESCRIPTION
## Summary
- mention the new default model `gemini-1.5-pro`
- explain how to set `GEMINI_MODEL` in `.env` to use a different model

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68587b90f7f0832eb5a59cb26aebf00b