### PR TITLE
Add customizable Gemini model

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ To run the API you need to provide a `GEMINI_API_KEY` environment variable.
 1. Create a new project on Vercel and link it to this repository.
 2. In the Vercel dashboard, open **Settings** → **Environment Variables**.
 3. Add a variable named `GEMINI_API_KEY` with the same value used locally.
-4. Trigger a deployment—Vercel will provide the `GEMINI_API_KEY` to your API at build time.
+4. *(Optional)* Add a variable named `GEMINI_MODEL` to override the default model.
+5. Trigger a deployment—Vercel will provide these variables to your API at build time.
 
 ## Pushing to GitHub
 

--- a/api/quote.js
+++ b/api/quote.js
@@ -1,3 +1,5 @@
+const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-1.5-pro";
+
 export default async function handler(req, res) {
   const prompt = req.query.prompt;
   const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
@@ -11,9 +13,8 @@ export default async function handler(req, res) {
   }
 
   try {
-    const modelName = process.env.GEMINI_MODEL || "gemini-1.5-pro";
     const result = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${GEMINI_API_KEY}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- allow customizing the Gemini model via `GEMINI_MODEL`
- document optional `GEMINI_MODEL` usage in README

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68587c154c58832e9ce883b06643dafb